### PR TITLE
fix: destructured jwt, ordering payload

### DIFF
--- a/src/odbIdentityProvider.js
+++ b/src/odbIdentityProvider.js
@@ -26,8 +26,8 @@ class OdbIdentityProvider {
 
   async signIdentity (data, { space }) {
     const payload = {
-      data,
-      iat: null
+      iat: null,
+      data
     }
     const opts = !space ? { use3ID: true } : { space }
     return (await this.threeId.signJWT(payload, opts)).split('.')[2]


### PR DESCRIPTION
always a problem serializing/signing a json object, that order is not defined, usually less of an issue with jwt since entire payload and signature included together, but here when verifying its de-structured where we pull the signature from else where, so if payload encoding not deterministic, can cause issues. 

Not exactly clear why worked in chrome before this fix, and then 3id-connect+safari didnt work, havent spent time on follow up yet. 